### PR TITLE
Added feature to add custom download function in export options.

### DIFF
--- a/highcharts-export-clientside.js
+++ b/highcharts-export-clientside.js
@@ -470,7 +470,7 @@
         steps.rendering[type].postRender(highChartsObject, context);
       }
 
-      steps.download(highChartsObject, context, data);
+      (opt.get('download')||steps.download)(highChartsObject, context, data);
     });
   }
 


### PR DESCRIPTION
I am implementing a bulk download in a zip file feature for graphs and ran across this problem.
I think this is a pretty general case problem that can be useful to a lot of people.
