### PR TITLE
Ensure csv/xls mimetypes are present

### DIFF
--- a/highcharts-export-clientside.js
+++ b/highcharts-export-clientside.js
@@ -41,7 +41,9 @@
     "downloadPDF": "application/pdf",
     "downloadPNG": "image/png",
     "downloadJPEG": "image/jpeg",
-    "downloadSVG": "image/svg+xml"
+    "downloadSVG": "image/svg+xml",
+    "downloadCSV": "text/csv",
+    "downloadXLS": "application/vnd.ms-excel"
   };
   TRANSLATION_KEY_TO_MIME_TYPES[H.getOptions().lang.downloadCSV || 'Download CSV'] = "text/csv";
   TRANSLATION_KEY_TO_MIME_TYPES[H.getOptions().lang.downloadXLS || 'Download XLS'] = "application/vnd.ms-excel";


### PR DESCRIPTION
I was having an issue where the filenames for CSV and XLS files were
being downloaded as the full text of the USE_TITLE_FOR_FILENAME
function. This commit ensures that the xls and csv mime types will be
included regardless of the specific text in the csv/xls download
buttons.

Thanks for writing a great and extremely useful plugin for this!
