### PR TITLE
Changing the order of browserSupportBlob and browserSupportDownload c…

### DIFF
--- a/highcharts-export-clientside.js
+++ b/highcharts-export-clientside.js
@@ -388,17 +388,17 @@
       throw new Error("Something went wrong while exporting the chart");
     }
 
-    if (context.browserSupportDownload && (data.datauri || data.content)) {
-      a = document.createElement('a');
-      a.href = data.datauri || ('data:' + context.type + ';base64,' + window.btoa(unescape(encodeURIComponent(data.content))));
-      a.download = context.filename;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-    }
-    else if (context.browserSupportBlob && (data.blob || data.content)) {
+    if (context.browserSupportBlob && (data.blob || data.content)) {
       blobObject = data.blob || new Blob([data.content], { type: context.type });
       window.navigator.msSaveOrOpenBlob(blobObject, context.filename);
+    }
+    else if (context.browserSupportDownload && (data.datauri || data.content)) {
+        a = document.createElement('a');
+        a.href = data.datauri || ('data:' + context.type + ';base64,' + window.btoa(unescape(encodeURIComponent(data.content))));
+        a.download = context.filename;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
     }
     else {
       window.open(data);


### PR DESCRIPTION
…hecks
Microsoft EDGE boasts that it can do both, browserSupportDownload and browserSupportBlob but it miserably fails after the sequence
a.click()
a.remove()
Changing the order makes browserSupportBlob method to be the preferred one, which in turn works fine for EDGE browsers.
